### PR TITLE
Fix and improve SARS-CoV-2 open pipeline

### DIFF
--- a/src/main/kotlin/org/genspectrum/ingest/workflow/SC2GisaidWorkflow.kt
+++ b/src/main/kotlin/org/genspectrum/ingest/workflow/SC2GisaidWorkflow.kt
@@ -298,7 +298,7 @@ fun mergeUnchangedAndNew(outputDirectory: Path, unchangedFilePath: File, joinedF
     return outputFile
 }
 
-fun moveFinalFiles(hashesFile: File, provisionFile: File, directoryPath: Path): Pair<File, File> {
+private fun moveFinalFiles(hashesFile: File, provisionFile: File, directoryPath: Path): Pair<File, File> {
     val zoneId = ZoneId.systemDefault()
     val newDataVersion = Instant.now().atZone(zoneId).toEpochSecond()
     val finalHashesFile = File(

--- a/src/main/kotlin/org/genspectrum/ingest/workflow/SC2NextstrainOpenWorkflow.kt
+++ b/src/main/kotlin/org/genspectrum/ingest/workflow/SC2NextstrainOpenWorkflow.kt
@@ -71,7 +71,7 @@ private fun downloadFromNextstrain(file: OpenFiles, outputDirectory: Path): File
         OpenFiles.TRANSLATION_ORF9b -> fastaTemplate.copy(name = "translation_ORF9b")
         OpenFiles.TRANSLATION_S -> fastaTemplate.copy(name = "translation_S")
     }
-    val url = URL("https://data.nextstrain.org/files/ncov/open/${outputFile.name}")
+    val url = URL("https://data.nextstrain.org/files/ncov/open/${outputFile.filename}")
     url.openStream().use { input ->
         Files.copy(input, outputFile.path, StandardCopyOption.REPLACE_EXISTING)
     }


### PR DESCRIPTION
- The final output is now moved to the `00_archive` folder.
- A bug when downloading open data was fixed.